### PR TITLE
Mounting Issue For wazuh manager

### DIFF
--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -60,7 +60,8 @@ RUN mkdir -p /var/ossec/var/multigroups && \
     chown root:wazuh /var/ossec/active-response/bin && \
     chmod 770 /var/ossec/active-response/bin
 
-COPY config/wazuh_manager.conf /wazuh-config-mount/etc/ossec.conf
+COPY config/wazuh_manager.conf /var/ossec/etc/ossec.conf
+RUN chown root:wazuh /var/ossec/etc/ossec.conf && chmod 640 /var/ossec/etc/ossec.conf
 COPY config/wazuh_indexer_ssl_certs/* /etc/ssl/
 
 # Services ports

--- a/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init
+++ b/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init
@@ -131,15 +131,15 @@ create_ossec_key_cert() {
 # replace the ossec.conf file in /var/ossec/data/etc with yours.
 ##############################################################################
 
-mount_files() {
-  if [ -e "$WAZUH_CONFIG_MOUNT" ]
-  then
-    print "Identified Wazuh configuration files to mount..."
-    exec_cmd_stdout "cp --verbose -r $WAZUH_CONFIG_MOUNT/* $WAZUH_INSTALL_PATH"
-  else
-    print "No Wazuh configuration files to mount..."
-  fi
-}
+# mount_files() {
+#   if [ -e "$WAZUH_CONFIG_MOUNT" ]
+#   then
+#     print "Identified Wazuh configuration files to mount..."
+#     exec_cmd_stdout "cp --verbose -r $WAZUH_CONFIG_MOUNT/* $WAZUH_INSTALL_PATH"
+#   else
+#     print "No Wazuh configuration files to mount..."
+#   fi
+# }
 
 
 ##############################################################################
@@ -218,7 +218,7 @@ main() {
   fi
 
   # Mount selected files (WAZUH_CONFIG_MOUNT) to container
-  mount_files
+  # mount_files
 
   # Allow setting custom hostname
   set_custom_hostname


### PR DESCRIPTION
In SIEM Wazuh, we were facing an issue with persistent data. Whenever changes were made to the configuration, such as updating alert logs from the default value of 3 to 7, the changes were successfully synced to the volume in both the container and the host. However, upon restarting the container, the configuration was overwritten with default values, causing the loss of updated settings and backup data. This task was aimed at addressing this issue and ensuring that the configuration changes persist across container restarts.